### PR TITLE
Adding README type annotations, fixing shell interpolation bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ pip install -e .
 
 Basic Usage
 ```bash
-kubesql "SELECT * from pods WHERE namespace = 'kube-system'"
+kubesql "SELECT * from pods WHERE namespace = 'kube-system'" > pods.csv
 ```
 
 Basic query

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@ Query kubernetes clusters using SQL
 
 ## Usage
 Install locally
-```
+```bash
 pip install -e .
 ```
 
 Basic Usage
-```
-kubesql SELECT * from pods WHERE namespace = 'kube-system' > pods.csv
+```bash
+kubesql "SELECT * from pods WHERE namespace = 'kube-system'"
 ```
 
 Basic query
-```
+```sql
 SELECT * from pods WHERE namespace = 'kube-system'
 ```
 


### PR DESCRIPTION
Some touch ups to the README.

Breaks:

```
$ kubesql SELECT * from pods WHERE namespace = 'kube-system'
SQL ERROR: Expecting one of (union, order by, from, offset, limit) (at char 18), (line:1, col:19)
```

Works:

```
$ kubesql "SELECT * from pods WHERE namespace = 'kube-system'"
annotations,creationTimestamp,generateName,labels,name,namespace,ownerReferences,resourceVersion,selfLink,uid,affinity,containers,dnsPolicy,enableServiceLinks,hostNetwork,nodeName,priority,priorityClassName,restartPolicy,schedulerName,securityContext,serviceAccount,serviceAccountName,terminationGracePeriodSeconds,tolerations,volumes
<dict>,2020-04-20T08:49:46Z,aws-node-,<dict>,aws-node-2khpn,kube-system,<list>,39712196,/api/v1/namespaces/kube-system/pods/aws-node-2khpn,da5a553a-2a30-4a07-a2ce-00d11902ac09,<dict>,<list>,ClusterFirst,True,True,ip-172-31-74-3.us-east-2.compute.internal,2000001000,system-node-critical,Always,default-scheduler,<dict>,aws-node,aws-node,30,<list>,<list>
```